### PR TITLE
docs: 修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,17 +233,17 @@ docker run \
   <source
     media="(prefers-color-scheme: dark)"
     srcset="
-      https://api.star-history.com/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date&theme=dark
+      https://star-history.dera.page/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date&theme=dark
     "
   />
   <source
     media="(prefers-color-scheme: light)"
     srcset="
-      https://api.star-history.com/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date
+      https://star-history.dera.page/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date
     "
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date"
+    src="https://star-history.dera.page/svg?repos=Coooolfan/XiaomiAlbumSyncer&type=Date"
   />
 </picture>


### PR DESCRIPTION
README 中的 Star History 图表当前因 GitHub 限制而无法正常显示，现更新图表链接以恢复其展示，保证仓库的 Star 趋势图重新可用。